### PR TITLE
Add check that we could call git commands in scoupe of buck

### DIFF
--- a/.github/workflows/buck_build.yml
+++ b/.github/workflows/buck_build.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build our program
       id: build
-      uses: SandakovMM/build-with-buck@v2
+      uses: SandakovMM/build-with-buck@v3
       with:
         command: build
         target: :result

--- a/BUCK
+++ b/BUCK
@@ -1,5 +1,11 @@
 # vim:ft=python:
 
+genrule(
+    name = 'version',
+    out = 'version.json',
+    bash = r"""echo "{\"revision\": \"`git rev-parse HEAD`\"}" > $OUT""",
+)
+
 python_library(
     name='library.lib',
     srcs=[
@@ -13,6 +19,9 @@ python_library(
     srcs=['main.py'],
     deps=[
         ':library.lib',
+    ],
+    resources = [
+        ':version',
     ],
 )
 


### PR DESCRIPTION
Fixed by new version of build-with-buck that uses default github action user (uid 1001)